### PR TITLE
compileDenseDesignMatrix has massive speedup over sparse version

### DIFF
--- a/+buildGLM/compileDenseDesignMatrix.m
+++ b/+buildGLM/compileDenseDesignMatrix.m
@@ -1,0 +1,42 @@
+function dm = compileDenseDesignMatrix(dspec, trialIndices)
+% Compile information from experiment according to given DesignSpec
+
+expt = dspec.expt;
+subIdxs = buildGLM.getGroupIndicesFromDesignSpec(dspec);
+
+trialT = ceil([expt.trial(trialIndices).duration]/expt.binSize);
+totalT = sum(trialT);
+X      = zeros(totalT, dspec.edim);
+
+trialIndices = trialIndices(:)';
+
+for kTrial = trialIndices
+    ndx = sum(trialT(1:kTrial))-(trialT(kTrial)-1):sum(trialT(1:kTrial));
+        
+    for kCov = 1:numel(dspec.covar) % for each covariate
+        covar = dspec.covar(kCov);
+        sidx = subIdxs{kCov};
+        
+        if isfield(covar, 'cond') && ~isempty(covar.cond) && ~covar.cond(expt.trial(kTrial))
+            continue;
+        end
+        
+        stim = covar.stim(expt.trial(kTrial), trialT(kTrial)); % either dense or sparse
+        stim = full(stim);
+        
+        if isfield(covar, 'basis') && ~isempty(covar.basis)
+            X(ndx, sidx) = basisFactory.convBasis(stim, covar.basis, covar.offset);
+        else
+            X(ndx, sidx) = stim;
+        end
+    end
+end
+
+dm.X = X;
+dm.trialIndices = trialIndices;
+dm.dspec = dspec;
+
+%% Check sanity of the design
+if any(~isfinite(dm.X(:)))
+    warning('Design matrix contains NaN or Inf...this is not good!');
+end


### PR DESCRIPTION
For 300 trials... it gets worse with more data. I don't think the design matrix is sparse enough to benefit from keeping it a sparse matrix. Obviously there's a tradeoff with memory, but we'll deal with that later.

Sparse elapsed time is 57.598149 seconds.
Dense elapsed time is 2.306020 seconds.
