### PR TITLE
bug in compileSparseDesignMatrix

### DIFF
--- a/+buildGLM/addCovariateSpiketrain.m
+++ b/+buildGLM/addCovariateSpiketrain.m
@@ -1,4 +1,6 @@
 function dspec = addCovariateSpiketrain(dspec, covLabel, stimLabel, desc, basisStruct, varargin)
+% add spike train as covariate
+% dspec = addCovariateSpiketrain(dspec, covLabel, stimLabel, desc, basisStruct, varargin)
 
 if nargin < 4; desc = covLabel; end
 

--- a/+buildGLM/addCovariateSpiketrain.m
+++ b/+buildGLM/addCovariateSpiketrain.m
@@ -1,6 +1,28 @@
 function dspec = addCovariateSpiketrain(dspec, covLabel, stimLabel, desc, basisStruct, varargin)
 % add spike train as covariate
-% dspec = addCovariateSpiketrain(dspec, covLabel, stimLabel, desc, basisStruct, varargin)
+% dspec = addCovariateSpiketrain(dspec, covLabel, stimLabel, desc, basisStruct, cond)
+%
+% Input
+%   dspec: struct - design specification object (see initDesignSpec)
+%   covLabel: string - name to refer to the covariate
+%   stimLabel: string - label from trial struct-array
+%   desc: string  - human readable description of the covariate
+%   stimHandle: @(trial, expt) -> [T x m] the raw stimulus design before 
+%	applying the basis functions.
+%   basisStruct: struct - temporal basis functions that will be convolved with
+%	the output of the stimHandle. See +basisFactory functions (e.g. 
+%	+basisFactory.makeSmoothTemporalBasis)
+%   offset: [1] optional/default:0 - number of **time bins** to shift the
+%	regressors. Negative (positive) integers represent acausal (causal)
+%	effects.
+%   cond: @(trial) -> boolean optional: condition for which the covariate will
+%	be included. For example, if only trials where 'choice' is 1 to include
+%	the current covariate, use @(trial) (trial.choice == 1)
+%
+% Output
+%   dspec: updated design specification object
+%
+% See also: addCovariateTiming, addCovariateRaw, addCovariateBoxcar, addCovariateSpiketrain
 
 if nargin < 4; desc = covLabel; end
 

--- a/+buildGLM/combineWeights.m
+++ b/+buildGLM/combineWeights.m
@@ -15,6 +15,8 @@ binSize = dspec.expt.binSize;
 if isfield(dm, 'biasCol') % undo z-score operation
     wout.bias = w(dm.biasCol);
     w(dm.biasCol) = [];
+    dm.zscore.sigma(dm.biasCol) = [];
+    dm.zscore.mu(dm.biasCol) = [];
 end
 
 if isfield(dm, 'zscore') % undo z-score operation

--- a/+buildGLM/compileDenseDesignMatrix.m
+++ b/+buildGLM/compileDenseDesignMatrix.m
@@ -21,7 +21,6 @@ for kTrial = trialIndices
             continue;
         end
         
-%         stim = covar.stim(expt.trial(kTrial), trialT(kTrial)); % either dense or sparse
         stim = covar.stim(expt.trial(kTrial), expt); % either dense or sparse
         stim = full(stim);
         

--- a/+buildGLM/compileDenseDesignMatrix.m
+++ b/+buildGLM/compileDenseDesignMatrix.m
@@ -21,7 +21,8 @@ for kTrial = trialIndices
             continue;
         end
         
-        stim = covar.stim(expt.trial(kTrial), trialT(kTrial)); % either dense or sparse
+%         stim = covar.stim(expt.trial(kTrial), trialT(kTrial)); % either dense or sparse
+        stim = covar.stim(expt.trial(kTrial), expt); % either dense or sparse
         stim = full(stim);
         
         if isfield(covar, 'basis') && ~isempty(covar.basis)

--- a/+buildGLM/compileSparseDesignMatrix.m
+++ b/+buildGLM/compileSparseDesignMatrix.m
@@ -23,7 +23,7 @@ for kTrial = trialIndices
             continue;
         end
         
-        stim = covar.stim(expt.trial(kTrial), nT); % either dense or sparse
+        stim = covar.stim(expt.trial(kTrial), expt); % either dense or sparse
         
         if isfield(covar, 'basis') && ~isempty(covar.basis)
             miniX(:, sidx) = basisFactory.convBasis(stim, covar.basis, covar.offset);


### PR DESCRIPTION
I believe there was a bug in compileSparseDesignMatrix with the calling of the stimHandle for each covariate (line 26). stimHandle takes (trial,expt), not (trial,nT)... it doesn't seem to matter because nT isn't used, but it seems wrong to me.

I started adding help documentation to addCovariateSpiketrain. This is not finished.
