### PR TITLE
zscoring and offset

### DIFF
--- a/+basisFactory/deltaStim.m
+++ b/+basisFactory/deltaStim.m
@@ -1,6 +1,7 @@
 function stim = deltaStim(bt, nT, v)
 % Returns a sparse vector with events at binned timings
 
+bt(bt>nT) = [];
 o = ones(numel(bt), 1);
 
 if nargin < 3

--- a/+buildGLM/addCovariateSpiketrain.m
+++ b/+buildGLM/addCovariateSpiketrain.m
@@ -33,8 +33,7 @@ end
 assert(ischar(desc), 'Description must be a string');
 
 offset = 1; % Make sure to be causal. No instantaneous interaction allowed.
-
 binfun = dspec.expt.binfun;
-stimHandle = @(trial, expt) basisFactory.deltaStim(binfun(trial.(stimLabel)), binfun(trial.duration));
+stimHandle = @(trial, expt) basisFactory.deltaStim(binfun(trial.(stimLabel)+expt.binSize), binfun(trial.duration));
 
 dspec = buildGLM.addCovariate(dspec, covLabel, desc, stimHandle, basisStruct, offset, varargin{:});

--- a/+buildGLM/combineWeights.m
+++ b/+buildGLM/combineWeights.m
@@ -13,10 +13,17 @@ dspec = dm.dspec;
 binSize = dspec.expt.binSize;
 
 if isfield(dm, 'biasCol') % undo z-score operation
-    wout.bias = w(dm.biasCol);
+    if isfield(dm, 'zscore') % remove bias from zscore
+        zmu  = dm.zscore.sigma(dm.biasCol);
+        zsig = dm.zscore.mu(dm.biasCol);
+        dm.zscore.sigma(dm.biasCol) = [];
+        dm.zscore.mu(dm.biasCol) = [];
+    else
+        zmu  = 1;
+        zsig = 1;
+    end
+    wout.bias = w(dm.biasCol)*zsig + zmu; % un-z-transform the bias
     w(dm.biasCol) = [];
-    dm.zscore.sigma(dm.biasCol) = [];
-    dm.zscore.mu(dm.biasCol) = [];
 end
 
 if isfield(dm, 'zscore') % undo z-score operation


### PR DESCRIPTION
Binning and offsetting to make coupling (and history) filters causal the way we were doing it somehow got rid of the refractory period in cells that had clear refractory periods. I think that the offset needs to be implemented before the binning (which rounds). 

When combining weights, we have to account for zscoring the bias term.
