### PR TITLE
Fix bug in makeNonlinearRaisedCos.m, add doc about unit of offset

### DIFF
--- a/+basisFactory/makeNonlinearRaisedCos.m
+++ b/+basisFactory/makeNonlinearRaisedCos.m
@@ -5,9 +5,9 @@ function bases = makeNonlinearRaisedCos(nBases, binSize, endPoints, nlOffset)
 % 	nBases: [1] - # of basis vectors
 %	binSize: time bin size (separation for representing basis
 %   endPoints: [2 x 1] = 2-vector containg [1st_peak  last_peak], the peak
-%          (i.e. center) of the last raised cosine basis vectors
-%   nlOffset: [1] offset for nonlinear stretching of x axis:  y = log(t+nlOffset)
-%         (larger nlOffset -> more nearly linear stretching)
+%          (i.e. center) of the last raised cosine basis vectors (in ms)
+%   nlOffset: [1] offset for nonlinear stretching of x axis (in ms): 
+%          y = log(t+nlOffset) (larger nlOffset -> more nearly linear stretching)
 %
 %  Outputs:  iht = time lattice on which basis is defined
 %            ihbasis = basis itself
@@ -28,7 +28,7 @@ yrnge = nlin(endPoints + nlOffset);
 db = diff(yrnge) / (nBases-1); % spacing between raised cosine peaks
 ctrs = yrnge(1):db:yrnge(2); % centers for basis vectors
 mxt = invnl(yrnge(2)+2*db) - nlOffset; % maximum time bin
-iht = (0:binSize:mxt)';
+iht = (0:binSize:mxt)'/binSize;
 ff = @(x,c,dc) (cos(max(-pi, min(pi, (x-c)*pi/dc/2))) + 1)/2;
 ihbasis = ff(repmat(nlin(iht + nlOffset), 1, nBases), repmat(ctrs, numel(iht), 1), db);
 ihctrs = invnl(ctrs);

--- a/+buildGLM/addCovariateBoxcar.m
+++ b/+buildGLM/addCovariateBoxcar.m
@@ -1,4 +1,9 @@
 function dspec = addCovariateBoxcar(dspec, covLabel, startLabel, endLabel, desc, varargin)
+%
+% Input
+%   offset: [1] optional/default: 0 - number of **time bins** to shift the
+%	regressors. Negative (positive) integers represent anti-causal (causal)
+%	effects.
 
 if nargin < 5; desc = covLabel; end
 

--- a/+buildGLM/addCovariateSpiketrain.m
+++ b/+buildGLM/addCovariateSpiketrain.m
@@ -1,14 +1,21 @@
 function dspec = addCovariateSpiketrain(dspec, covLabel, stimLabel, desc, basisStruct, varargin)
+%
+% Input
+%   offset: [1] optional/default: 1 - number of **time bins** to shift the
+%	regressors. Negative (positive) integers represent anti-causal (causal)
+%	effects.
 
 if nargin < 4 || isempty(desc); desc = covLabel; end
 
 if nargin < 5
-    basisStruct = basisFactory.makeNonlinearRaisedCos(10, dspec.expt.binSize, [0 100], 2);
+    basisStruct = basisFactory.makeNonlinearRaisedCos(10, dspec.expt.binSize, [0 100], 1);
 end
 
 assert(ischar(desc), 'Description must be a string');
 
-offset = 1; % Make sure to be causal. No instantaneous interaction allowed.
+offset = basisStruct.param.nlOffset; % Make sure to be causal. No instantaneous interaction allowed.
+
+assert(offset>0, 'Offset must be >0');
 
 binfun = dspec.expt.binfun;
 stimHandle = @(trial, expt) basisFactory.deltaStim(binfun(trial.(stimLabel)), binfun(trial.duration));

--- a/+buildGLM/addCovariateTiming.m
+++ b/+buildGLM/addCovariateTiming.m
@@ -1,6 +1,11 @@
 function dspec = addCovariateTiming(dspec, covLabel, stimLabel, desc, varargin)
 % Add a timing covariate based on the stimLabel.
 % dspec = addCovariateTiming(dspec, covLabel, stimLabel, desc, basisStruct, offset, cond, plotOpts);
+%
+% Input
+%   offset: [1] optional/default: 0 - number of **time bins** to shift the
+%	regressors. Negative (positive) integers represent anti-causal (causal)
+%	effects.
 
 if ~isstruct(dspec)
     error('First argument must be a design specification structure');


### PR DESCRIPTION
In makeNonlinearRaisedCos.m, the time vector of the basis function is wrong if unitOfTime is not ms.
In all these functions, the input variable offset should be provided in ms or number of time bins, but is not specified in the doc lines within each function.